### PR TITLE
Feature/persistence

### DIFF
--- a/index.js
+++ b/index.js
@@ -455,9 +455,9 @@ class Analytics {
       this.flush();
     }
 
-    if (this.flushInterval && !this.timer) {
-      this.timer = setTimeout(this.flush.bind(this), this.flushInterval);
-    }
+    // if (this.flushInterval && !this.timer) {
+    //   this.timer = setTimeout(this.flush.bind(this), this.flushInterval);
+    // }
   }
 
   /**
@@ -548,7 +548,8 @@ class Analytics {
       this.pQueue
         .add({ eventData: serialize(eventData) })
         .then(pushedJob => {
-          this.queue.splice(0, this.flushAt);
+          this.queue.splice(0, items.length);
+          this.timer = setTimeout(this.flush.bind(this), this.flushInterval);
           this.state = "idle";
         })
         .catch(error => {
@@ -568,12 +569,14 @@ class Analytics {
         }
       })
         .then(response => {
-          this.queue.splice(0, this.flushAt);
+          this.queue.splice(0, items.length);
+          this.timer = setTimeout(this.flush.bind(this), this.flushInterval);
           this.state = "idle";
           done();
         })
         .catch(err => {
-          this.queue.splice(0, this.flushAt);
+          this.queue.splice(0, items.length);
+          this.timer = setTimeout(this.flush.bind(this), this.flushInterval);
           this.state = "idle";
           if (err.response) {
             const error = new Error(err.response.statusText);

--- a/index.js
+++ b/index.js
@@ -189,7 +189,7 @@ class Analytics {
     this.pJobOpts = this.pQueueOpts.jobOpts || {};
     this.pQueue = new Queue(this.pQueueOpts.queueName || "rudderEventsQueue", {
       redis: this.pQueueOpts.redisOpts,
-      prefix: this.pQueueOpts.prefix || "rudder"
+      prefix: "{" + this.pQueueOpts.prefix + "}" || "{rudder}"
     });
 
     console.log("isMultiProcessor" + this.pQueueOpts.isMultiProcessor);

--- a/index.js
+++ b/index.js
@@ -133,10 +133,15 @@ class Analytics {
                         " " +
                         err
                     );
+                  })
+                  .catch(error => {
+                    console.log("failed to requeue job " + jobData.description);
+                    rdone(jobData.callbacks, error);
+                    done(error);
                   });
               } else {
                 // if not retryable, mark the job failed and to failed queue for user to retry later
-                rdone(jobData.callbacks);
+                rdone(jobData.callbacks, err);
                 done(err);
               }
             });

--- a/index.js
+++ b/index.js
@@ -471,12 +471,14 @@ class Analytics {
     // check if earlier flush was pushed to queue
     console.log("in flush")
     if (this.state == "running") {
+      console.log("skipping flush, earlier flush in progress")
       return;
     }
     this.state = "running";
     callback = callback || noop;
 
     if (!this.enable) {
+      this.state = "idle";
       return setImmediate(callback);
     }
 
@@ -486,6 +488,7 @@ class Analytics {
     }
 
     if (!this.queue.length) {
+      this.state = "idle";
       return setImmediate(callback);
     }
 

--- a/index.js
+++ b/index.js
@@ -452,6 +452,7 @@ class Analytics {
     }
 
     if (this.queue.length >= this.flushAt) {
+      console.log("flushAt reached, trying flush...");
       this.flush();
     }
 
@@ -469,9 +470,9 @@ class Analytics {
 
   flush(callback) {
     // check if earlier flush was pushed to queue
-    console.log("in flush")
+    console.log("in flush");
     if (this.state == "running") {
-      console.log("skipping flush, earlier flush in progress")
+      console.log("skipping flush, earlier flush in progress");
       return;
     }
     this.state = "running";
@@ -488,6 +489,7 @@ class Analytics {
     }
 
     if (!this.queue.length) {
+      console.log("queue is empty, nothing to flush");
       this.state = "idle";
       return setImmediate(callback);
     }
@@ -552,7 +554,7 @@ class Analytics {
       this.pQueue
         .add({ eventData: serialize(eventData) })
         .then(pushedJob => {
-          console.log("pushed job to queue")
+          console.log("pushed job to queue");
           this.queue.splice(0, items.length);
           this.timer = setTimeout(this.flush.bind(this), this.flushInterval);
           this.state = "idle";
@@ -582,6 +584,11 @@ class Analytics {
           done();
         })
         .catch(err => {
+          console.log(
+            "got error while attempting send for 3 times, dropping " +
+              items.length +
+              " events"
+          );
           this.queue.splice(0, items.length);
           this.timer = setTimeout(this.flush.bind(this), this.flushInterval);
           this.state = "idle";
@@ -597,7 +604,6 @@ class Analytics {
   }
 
   _isErrorRetryable(error) {
-    
     // Retry Network Errors.
     if (axiosRetry.isNetworkError(error)) {
       return true;

--- a/index.js
+++ b/index.js
@@ -469,6 +469,7 @@ class Analytics {
 
   flush(callback) {
     // check if earlier flush was pushed to queue
+    console.log("in flush")
     if (this.state == "running") {
       return;
     }
@@ -548,11 +549,14 @@ class Analytics {
       this.pQueue
         .add({ eventData: serialize(eventData) })
         .then(pushedJob => {
+          console.log("pushed job to queue")
           this.queue.splice(0, items.length);
           this.timer = setTimeout(this.flush.bind(this), this.flushInterval);
           this.state = "idle";
         })
         .catch(error => {
+          this.timer = setTimeout(this.flush.bind(this), this.flushInterval);
+          this.state = "idle";
           console.log(
             "failed to push to redis queue, in-memory queue size: " +
               this.queue.length
@@ -590,6 +594,7 @@ class Analytics {
   }
 
   _isErrorRetryable(error) {
+    
     // Retry Network Errors.
     if (axiosRetry.isNetworkError(error)) {
       return true;
@@ -600,6 +605,7 @@ class Analytics {
       return false;
     }
 
+    console.log("error status: " + error.response.status);
     // Retry Server Errors (5xx).
     if (error.response.status >= 500 && error.response.status <= 599) {
       return true;

--- a/index.js
+++ b/index.js
@@ -240,7 +240,7 @@ class Analytics {
                       console.log("success removed active job");
                       let jobData = eval("(" + job.data.eventData + ")");
                       jobData.attempts = 0;
-                      payloadQueue
+                      this.pQueue
                         .add({ eventData: serialize(jobData) }, { lifo: true })
                         .then(removedJob => {
                           console.log(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "rudder-sdk-node-develop",
-  "version": "0.0.1",
+  "name": "@rudderstack/rudder-sdk-node",
+  "version": "1.0.1",
   "description": "Rudder Node SDK",
   "license": "",
   "repository": "rudderlabs/rudder-sdk-node",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@rudderstack/rudder-sdk-node",
-  "version": "0.0.3",
+  "name": "rudder-sdk-node-develop",
+  "version": "0.0.1",
   "description": "Rudder Node SDK",
   "license": "",
   "repository": "rudderlabs/rudder-sdk-node",
@@ -33,10 +33,12 @@
     "auto-changelog": "^1.16.2",
     "axios": "^0.19.0",
     "axios-retry": "^3.0.2",
+    "bull": "^3.20.0",
     "lodash.isstring": "^4.0.1",
     "md5": "^2.2.1",
     "ms": "^2.0.0",
     "remove-trailing-slash": "^0.1.0",
+    "serialize-javascript": "^5.0.1",
     "uuid": "^3.2.1"
   },
   "devDependencies": {

--- a/readme.md
+++ b/readme.md
@@ -12,7 +12,7 @@ $ npm install @rudderstack/rudder-sdk-node
 const Analytics = require("@rudderstack/rudder-sdk-node");
 
 // we need the batch endpoint of the Rudder server you are running
-const client = new Analytics("write key", "<data-plane-uri>/v1/batch"); 
+const client = new Analytics("write key", "<data-plane-uri>/v1/batch");
 
 client.track({
   event: "event name",
@@ -20,6 +20,80 @@ client.track({
 });
 ```
 
+## Initialization for persistence
+
+```
+const client = new Analytics(
+  "write_key",
+  "server_url/v1/batch",
+  {
+    flushAt: <number> = 20,
+    flushInterval: <ms> = 20000
+    maxInternalQueueSize: <number> = 20000 // the max number of elements that the SDK can hold in memory,
+                                                                // this is different than the Redis list created when persistence is enabled
+  }
+);
+client.createPersistenceQueue({ redisOpts: { host: "localhost" } }, err => {})
+```
+
+Adding a method **createPersistenceQueue** which takes as input two params **queueOpts** and a **callback**
+
+```
+QueueOpts {
+  queueName ?: string = rudderEventsQueue,
+  isMultiProcessor ? : boolean = false
+  prefix ? : string = {rudder},  // pass a value without the {}
+  redisOpts : RedisOpts,
+  jobOpts ?: JobOpts
+}
+
+https://github.com/OptimalBits/bull/blob/develop/REFERENCE.md#queue
+RedisOpts {
+ port?: number = 6379;
+ host?: string = localhost;
+ db?: number = 0;
+ password?: string;
+}
+
+JobOpts {
+  maxAttempts ? : number = 10
+}
+
+callback: function(error) || function() // createPersistenceQueue calls this with error or nothing(in case of success), user
+                                                                // should retry in case of error
+
+```
+
+The **createPersistenceQueue** method will initialize a Redis list by calling [Bull's](https://github.com/OptimalBits/bull) utility methods. It will also add a single job processor for processing(making requests to Rudder server) jobs that are pushed into the list. Before adding a processor, the SDK will remove the last active job(should be at max 1 active) if any and push it to be processed again in order. Error in doing this will lead to calling the **callback with error parameter**. Retry calling **createPersistenceQueue** with backoff.
+
+If the **createPersistenceQueue** method is not called after initialising the SDK by the user, the SDK will work with no persistence and the behaviour will be same as at present.
+
+### Flow
+
+- Calling SDK apis like track, page, identify etc will push the events to an in-memory array
+- the events from the array are flushed as a batch to Redis persistence based on the **flushAt** and **flushInterval** setting. Since, there is a communication to a separate process, tune the flushAt/flushInterval setting to slow down the hit to Redis. The in-memory array has a max size of **maxInternalQueueSize**, after which events won't be accepted if not drained at the other side (cases where Redis connection is slow etc)
+- The processor will take the batch formed in the above step from Redis list and make a request to Rudder server. If succeeded, the job will be pushed to completed queue in Redis (Bull npm package terminology). In case of notRetryable error(4xx mainly), the job will be moved to failed queue (Bull npm package terminology). These queues are persistent and can be inspected directly in Redis or using an queue viewer [like](https://github.com/vcapretz/bull-board).
+- In case of retryable errors, the job is pushed to completed queue and a new instance of job with the same batch data is created and pushed to front of the queue (to maintain order), so that the next job to be processed is the same (this is the retry functionality). This will go upto **JobOpts.maxAttempts** time with exponential backoff of power 2.
+- If the job failed even after **JobOpts.maxAttempts**, it is moved to failed queue( explained above ).
+- If the node process dies with jobs still in active state (not completed nor failed but in the process of sending/retrying), the **next time the SDK is initialised and createPersistenceQueue** is called, it will be removed and a new instance with the same batch data is pushed in front of the queue to picked up first by the processor.
+
+### Important Parameters
+
+- flushAt
+- flushInterval
+- maxInternalQueueSize
+- JobOpts.maxAttempts
+
+### Notes
+
+- **isMultiProcessor** flag determines whether to handle previously active jobs, if false => the active job handling from previous processor is applied else Bull handles it by moving it to back of waiting queue.
+
+### Limitation
+
+https://gitter.im/OptimalBits/bull/archives/2018/04/17
+**Details**: https://redis.io/topics/cluster-tutorial#redis-cluster-data-sharding
+**Workaround**: https://gitter.im/OptimalBits/bull/archives/2018/04/17, we are passing a prefix with default {rudder}
+
 ## Documentation
 
-Documentation is available at [https://segment.com/libraries/node](https://segment.com/libraries/node).
+Documentation is available at [Node SDK](https://docs.rudderstack.com/rudderstack-sdk-integration-guides/rudderstack-node-sdk).


### PR DESCRIPTION
## Description of the change
### Initialization
```
const client = new Analytics(
  "write_key",
  "server_url/v1/batch",
  {
    flushAt: <number> = 20,
    flushInterval: <ms> = 20000
    maxInternalQueueSize: <number> = 20000 // the max number of elements that the SDK can hold in memory,                                                                 
                                                                // this is different than the Redis list created when persistence is enabled
  }
);
client.createPersistenceQueue({ redisOpts: { host: "localhost" } }, err => {})
```
Adding a method **createPersistenceQueue** which takes as input two params **queueOpts** and a **callback**
```
QueueOpts {
  queueName ?: string = rudderEventsQueue,
  isMultiProcessor ? : boolean = false
  prefix ? : string = {rudder},  // pass a value without the {}
  redisOpts : RedisOpts,
  jobOpts ?: JobOpts
}

https://github.com/OptimalBits/bull/blob/develop/REFERENCE.md#queue
RedisOpts {
 port?: number = 6379;
 host?: string = localhost;
 db?: number = 0;
 password?: string;
}

JobOpts {
  maxAttempts ? : number = 10
}

callback: function(error) || function() // createPersistenceQueue calls this with error or nothing(in case of success), user 
                                                                // should retry in case of error

```

The **createPersistenceQueue** method will initialize a Redis list by calling [Bull's](https://github.com/OptimalBits/bull) utility methods. It will also add a single job processor for processing(making requests to Rudder server) jobs that are pushed into the list. Before adding a processor, the SDK will remove the last active job(should be at max 1 active) if any and push it to be processed again in order. Error in doing this will lead to calling the **callback with error parameter**.  Retry calling **createPersistenceQueue** with backoff.

If the **createPersistenceQueue** method is not called after initialising the SDK by the user, the SDK will work with no persistence and the behaviour will be same as at present.

### Flow

- Calling SDK apis like track, page, identify etc will push the events to an in-memory array
- the events from the array are flushed as a batch to Redis persistence based on the **flushAt** and **flushInterval** setting. Since, there is a communication to a separate process, tune the flushAt/flushInterval setting to slow down the hit to Redis. The in-memory array has a max size of **maxInternalQueueSize**, after which events won't be accepted if not drained at the other side (cases where Redis connection is slow etc)
- The processor will take the batch formed in the above step from Redis list and make a request to Rudder server. If succeeded, the job will be pushed to completed queue in Redis (Bull npm package terminology). In case of notRetryable error(4xx mainly), the job will be moved to failed queue  (Bull npm package terminology). These queues are persistent and can be inspected directly in Redis or using an queue viewer [like](https://github.com/vcapretz/bull-board).
- In case of retryable errors, the job is pushed to completed queue and a new instance of job with the same batch data is created and pushed to front of the queue (to maintain order), so that the next job to be processed is the same (this is the retry functionality). This will go upto **JobOpts.maxAttempts** time with exponential backoff of power 2.
- If the job failed even after **JobOpts.maxAttempts**, it is moved to failed queue( explained above ).
- If the node process dies with jobs still in active state (not completed nor failed but in the process of sending/retrying), the **next time the SDK is initialised and createPersistenceQueue** is called, it will be removed and a new instance with the same batch data is pushed in front of the queue to picked up first by the processor. 

### Important Parameters

- flushAt
- flushInterval
- maxInternalQueueSize
- JobOpts.maxAttempts

### Notes

- Few unhandled errors are there which I feel should stop the node process like error coming up from promises ex: Unhandled promise rejections. If the user of the SDK doesn't abort the process we can throw these explicitly and move jobs to failed queue etc.
- **isMultiProcessor** flag determines whether to handle previously active jobs, if false => the active job handling from previous processor is applied else Bull handles it by moving it to back of waiting queue.

### Limitation
https://gitter.im/OptimalBits/bull/archives/2018/04/17
**Details**: https://redis.io/topics/cluster-tutorial#redis-cluster-data-sharding
**Workaround**:  https://gitter.im/OptimalBits/bull/archives/2018/04/17, we are passing a prefix with default {rudder}

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

