### PR TITLE
Add index.d.ts file to build

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "dependencies": "yarn",
     "size": "size-limit",
-    "build": "babel index.js --out-dir lib && cp package.json lib/ && cp readme.md lib/ && cp History.md lib/ && cp LICENSE.md lib/",
+    "build": "babel index.js --out-dir lib && cp package.json lib/ && cp readme.md lib/ && cp History.md lib/ && cp LICENSE.md lib/ && cp index.d.ts lib/",
     "test": "nyc --reporter=lcov --reporter=html --reporter=text ava --serial --verbose  > coverage.lcov",
     "lint": "eslint . --fix",
     "changelog": "auto-changelog -p -t keepachangelog -u true -l false --sort-commits date-desc ",


### PR DESCRIPTION
## Description of the change

I get this error on my project:

```
error TS2307: Cannot find module '@rudderstack/rudder-sdk-node' or its corresponding type declarations.
import Analytics from "@rudderstack/rudder-sdk-node"

```
> I believe that adding the file index.d.ts to build solves the problem, please correct me if I'm wrong

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
