### PR TITLE
concurrency added for flush

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ coverage
 .nyc_output
 coverage.lcov
 lib
+./example/node_modules
+./example/package-lock.json

--- a/example/app.js
+++ b/example/app.js
@@ -7,7 +7,7 @@ const client = new Rudderanalytics(writeKey, `${dataPlaneURL}/v1/batch`, {
   // flushAt: 2,
 });
 /**
- * Sample function to send 3 rudder events[identify,track,track] a make sure it's completion by promosifiying the flush
+ * Sample function to send 3 rudder events[identify,track,track] and make sure it's completion by promosifiying the flush
  */
 async function test() {
   // promisify the flush method
@@ -29,7 +29,6 @@ async function test() {
       console.log("In identify call");
     }
   );
-  console.log("2");
 
   client.track(
     {

--- a/example/app.js
+++ b/example/app.js
@@ -1,0 +1,70 @@
+const Rudderanalytics = require("@rudderstack/rudder-sdk-node"); // use latest package
+
+const writeKey = "WRITE_KEY"; // replace with your write-key
+const dataPlaneURL = "DATA_PLANE_URL"; // replace with your data plane url
+
+const client = new Rudderanalytics(writeKey, `${dataPlaneURL}/v1/batch`, {
+  // flushAt: 2,
+});
+/**
+ * Sample function to send 3 rudder events[identify,track,track] a make sure it's completion by promosifiying the flush
+ */
+async function test() {
+  // promisify the flush method
+  const flush = () => new Promise((resolve) => client.flush(resolve));
+
+  // call RS client methods as normal –
+  // no promisify or await needed and called concurrently
+  client.identify(
+    {
+      userId: "Test user 1",
+      traits: {
+        name: "Name Username",
+        email: "name@website.com",
+        plan: "Free",
+        friends: 21,
+      },
+    },
+    () => {
+      console.log("In identify call");
+    }
+  );
+  console.log("2");
+
+  client.track(
+    {
+      userId: "Test user 1",
+      event: "Item Purchased",
+      properties: {
+        revenue: 19.95,
+        shippingMethod: "Premium",
+      },
+    },
+    () => {
+      console.log("In track call");
+    }
+  );
+  client.track(
+    {
+      userId: "Test user 2",
+      event: "Item Viewed",
+      properties: {
+        price: 45,
+        currency: "USD",
+        productId: "Product-12345",
+      },
+    },
+    () => {
+      console.log("In track call 2");
+    }
+  );
+
+  // this both flushes and ensures completion
+  await flush();
+}
+
+test().then(() => {
+  console.log("test call done");
+});
+
+exports.Rudderanalytics = Rudderanalytics;

--- a/example/app.js
+++ b/example/app.js
@@ -68,3 +68,5 @@ test().then(() => {
 });
 
 exports.Rudderanalytics = Rudderanalytics;
+
+// run this file with the command "node app"

--- a/example/package.json
+++ b/example/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "dummy-node-project",
+  "version": "1.0.0",
+  "description": "",
+  "main": "app.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@rudderstack/rudder-sdk-node": "^1.0.14"
+  }
+}

--- a/index.js
+++ b/index.js
@@ -634,10 +634,7 @@ class Analytics {
         })
         .catch((error) => {
           this.timer = setTimeout(this.flush.bind(this), this.flushInterval);
-          const temp = eventData.request.data.batch.map((e) => {
-            return { message: e };
-          });
-          this.queue.unshift(temp);
+          this.queue.unshift(items);
           this.logger.error(
             "failed to push to redis queue, in-memory queue size: " +
               this.queue.length

--- a/test.js
+++ b/test.js
@@ -214,10 +214,10 @@ test("enqueue - flush on first message", (t) => {
   t.true(client.flush.calledOnce);
 
   client.enqueue("type", {});
-  t.false(client.flush.calledOnce);
+  t.true(client.flush.calledOnce);
 
   client.enqueue("type", {});
-  t.false(client.flush.calledTwice);
+  t.true(client.flush.calledTwice);
 });
 
 test("enqueue - flush the queue if it hits the max length", (t) => {


### PR DESCRIPTION
## Description of the change

- Added concurrency
- Removed state variable check while one flush is in progress.
- In case the system fails to push the data to a persistent queue will add back to the in-memory queue.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
