### PR TITLE
fix: library info override when provided in context

### DIFF
--- a/index.js
+++ b/index.js
@@ -514,11 +514,11 @@ class Analytics {
     lMessage.type = type;
 
     lMessage.context = {
+      ...lMessage.context,
       library: {
         name: 'analytics-node',
         version,
       },
-      ...lMessage.context,
     };
 
     lMessage.channel = 'server';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rudderstack/rudder-sdk-node",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Rudder Node SDK",
   "license": "",
   "repository": "rudderlabs/rudder-sdk-node",

--- a/test.js
+++ b/test.js
@@ -766,3 +766,26 @@ test('ensure other axios clients are not impacted by axios-retry', async (t) => 
 
   server.close();
 });
+
+test('ensure library information not overridden if provided in context object', (t) => {
+  const client = createClient();
+  const customContext = {
+    library: {
+      name: 'random-sdk',
+      version: '1234',
+    },
+  };
+
+  client.enqueue(
+    'type',
+    {
+      event: 'test',
+      context: customContext,
+    },
+    noop,
+  );
+
+  const actualContext = client.queue[0].message.context;
+
+  t.deepEqual(actualContext, context);
+});


### PR DESCRIPTION
## Description of the change

> Fixed the bug of system library info getting overridden by custom library information provided in the context

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
