### PR TITLE
fix: flush after a single event is sent

### DIFF
--- a/index.js
+++ b/index.js
@@ -601,6 +601,17 @@ class Analytics {
     }
 
     if (!this.queue.length) {
+      if (this.pendingFlush) {
+        this.logger.debug('queue is empty, but a flush already exists');
+        // We attach the callback to the end of the chain to support a caller calling `flush()` multiple times when the queue is empty.
+        this.pendingFlush = this.pendingFlush
+          .then(() => {
+            callback();
+            return Promise.resolve();
+          });
+        return this.pendingFlush;
+      }
+
       this.logger.debug('queue is empty, nothing to flush');
       setImmediate(callback);
       return Promise.resolve();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rudderstack/rudder-sdk-node",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@rudderstack/rudder-sdk-node",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "dependencies": {
         "@segment/loosely-validate-event": "^2.0.0",
         "axios": "0.26.0",


### PR DESCRIPTION
## Description of the change

When the first event is enqueued, a flush is triggered, but not awaited. If a caller calls flush after sending a single event, the call succeeds and the callback is called, even though there is a pending flush to be resolved.

This commit fixes this by chaining the callback received in the flush call to the flush already in progress.

**Note**: your pre-commit hook is currently failing linting on a lot of places unrelated to this PR. I checked that this PR doesn't introduce any new linting issues, but I also didn't fix all linting issues in this PR because it's out of its scope.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

No current related issues, but this might solve #79.

## Checklists

### Development

- [ ] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
