### PR TITLE
chore: use exact versions for github actions

### DIFF
--- a/.github/workflows/deploy-npm.yml
+++ b/.github/workflows/deploy-npm.yml
@@ -51,21 +51,27 @@ jobs:
 
       - name: Send message to Slack channel
         id: slack
-        uses: slackapi/slack-github-action@v1.27.1
+        continue-on-error: true
+        uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d  # v2.0.0
         env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-          PROJECT_NAME: 'Node SDK'
+          PROJECT_NAME: 'Node.js SDK'
           NPM_PACKAGE_URL: 'https://www.npmjs.com/package/@rudderstack/rudder-sdk-node'
+          RELEASES_URL: 'https://github.com/rudderlabs/rudder-sdk-node/releases/tag/v'
         with:
-          channel-id: ${{ secrets.SLACK_RELEASE_CHANNEL_ID }}
+          method: chat.postMessage
+          payload-templated: true
+          retries: rapid
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
           payload: |
             {
+              "channel": "${{ secrets.SLACK_RELEASE_CHANNEL_ID }}",
+              "text": "*New Release: ${{ env.PROJECT_NAME }} - <${{ env.NPM_PACKAGE_URL }}|${{ env.CURRENT_VERSION_VALUE }}>*\n${{ env.DATE }}\nCC: <!subteam^S0555JBV36D> <!subteam^S03SHJ20350>",
               "blocks": [
                 {
                   "type": "header",
                   "text": {
                     "type": "plain_text",
-                    "text": "New release: ${{ env.PROJECT_NAME }}"
+                    "text": "New Release: ${{ env.PROJECT_NAME }}"
                   }
                 },
                 {
@@ -75,8 +81,22 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "*Release: <${{ env.NPM_PACKAGE_URL }}|${{ env.CURRENT_VERSION_VALUE }}>*\n${{ env.DATE }}"
+                    "text": "*<${{ env.NPM_PACKAGE_URL }}|v${{ env.CURRENT_VERSION_VALUE }}>*\n${{ env.DATE }}\nCC: <!subteam^S0555JBV36D> <!subteam^S03SHJ20350>"
+                  },
+                  "accessory": {
+                    "type": "image",
+                    "image_url": "https://img.icons8.com/color/452/npm.png",
+                    "alt_text": "NPM Icon"
                   }
+                },
+                {
+                  "type": "context",
+                  "elements": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "For more details, check the full release notes <${{ env.RELEASES_URL }}${{ env.CURRENT_VERSION_VALUE }}|here>."
+                    }
+                  ]
                 }
               ]
             }

--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -77,10 +77,30 @@ jobs:
           git push
 
       - name: Create pull request into master
-        uses: repo-sync/pull-request@v2
-        with:
-          source_branch: ${{ steps.create-release.outputs.branch_name }}
-          destination_branch: 'master'
-          github_token: ${{ secrets.PAT }}
-          pr_title: 'chore(release): pulling ${{ steps.create-release.outputs.branch_name }} into master'
-          pr_body: ':crown: *An automated PR*'
+        env:
+          GH_TOKEN: ${{ secrets.PAT }}
+        run: |
+          pr_title="chore(release): merge ${{ steps.create-release.outputs.branch_name }} into master"
+          
+          # Create PR body with proper formatting
+          cat > pr_body.md << EOF
+          :crown: **Automated Release PR**
+
+          This pull request was created automatically by the GitHub Actions workflow. It merges the release branch (\`${{ steps.create-release.outputs.branch_name }}\`) into the \`master\` branch.
+
+          This ensures that the latest release branch changes are incorporated into the \`master\` branch for production.
+
+          ### Details
+          - **Release Version**: v${{ env.NEW_VERSION_VALUE }}
+          - **Release Branch**: \`${{ steps.create-release.outputs.branch_name }}\`
+
+          ---
+          Please review and merge when ready. :rocket:
+          EOF
+          
+          # Create the PR using GitHub CLI
+          gh pr create \
+            --base master \
+            --head ${{ steps.create-release.outputs.branch_name }} \
+            --title "$pr_title" \
+            --body-file pr_body.md

--- a/.github/workflows/housekeeping.yaml
+++ b/.github/workflows/housekeeping.yaml
@@ -1,13 +1,17 @@
-name: Handle stale PRs
+name: Handle Stale PRs and Branches
 
 on:
   schedule:
-    - cron: '42 1 * * *'
+    - cron: '1 0 * * *' # every day at 00:01
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.sha }}
+  cancel-in-progress: true
 
 jobs:
   prs:
-    name: Clean up stale prs
-    runs-on: ubuntu-latest
+    name: Clean up stale PRs
+    runs-on: [self-hosted, Linux, X64]
 
     permissions:
       issues: write
@@ -16,26 +20,28 @@ jobs:
     steps:
       - uses: actions/stale@v9
         with:
-          repo-token: ${{ github.token }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
           operations-per-run: 200
-          stale-pr-message: 'This PR is considered to be stale. It has been open 30 days with no further activity thus it is going to be closed in 10 days. To avoid such a case please consider removing the stale label manually or add a comment to the PR.'
-          days-before-pr-stale: 30
+          stale-pr-message: "Hello! This PR has been open for 20 days without any activity. Therefore, it's considered as stale and is scheduled to be closed in 10 days. If you're still working on this, please remove the 'Stale' label or add a comment to keep it open. Thanks for your contribution!"
+          days-before-pr-stale: 20
           days-before-pr-close: 10
           stale-pr-label: 'Stale'
+          ascending: true
 
   branches:
-    name: Cleanup old branches
-    runs-on: ubuntu-latest
+    name: Clean up stale branches
+    runs-on: [self-hosted, Linux, X64]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-
-      - name: Run delete-old-branches-action
-        uses: beatlabs/delete-old-branches-action@v0.0.10
         with:
-          repo_token: ${{ github.token }}
-          date: '2 months ago'
-          dry_run: false
-          delete_tags: false
-          extra_protected_branch_regex: ^(main|master|develop)$
-          exclude_open_pr_branches: true
+          fetch-depth: 0
+
+      - name: Run branch cleanup script
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          chmod +x ./scripts/cleanup-old-branches.sh
+          ./scripts/cleanup-old-branches.sh \
+            --months 2 \
+            --protected-branches "^(master|develop)$"

--- a/.github/workflows/publish-new-release.yml
+++ b/.github/workflows/publish-new-release.yml
@@ -53,10 +53,29 @@ jobs:
           echo "DATE=$(date)" >> $GITHUB_ENV
 
       - name: Create pull request into develop
-        uses: repo-sync/pull-request@v2
-        with:
-          source_branch: 'master'
-          destination_branch: 'develop'
-          github_token: ${{ secrets.PAT }}
-          pr_title: 'chore(release): pulling master into develop post release v${{ steps.extract-version.outputs.release_version }}'
-          pr_body: ':crown: *An automated PR*'
+        env:
+          GH_TOKEN: ${{ secrets.PAT }}
+        run: |
+          pr_title="chore(release): merge main into develop after release v${{ steps.extract-version.outputs.release_version }}"
+          
+          # Create PR body with proper formatting
+          cat > pr_body.md << EOF
+          :crown: **Automated Post-Release PR**
+
+          This pull request was created automatically by the GitHub Actions workflow. It merges changes from the \`master\` branch into the \`develop\` branch after a release has been completed.
+
+          This ensures that the \`develop\` branch stays up to date with all release-related changes from the \`master\` branch.
+
+          ### Details
+          - **Release Version**: v${{ steps.extract-version.outputs.release_version }}
+
+          ---
+          Please review and merge it before closing the release ticket. :rocket:
+          EOF
+          
+          # Create the PR using GitHub CLI
+          gh pr create \
+            --base develop \
+            --head master \
+            --title "$pr_title" \
+            --body-file pr_body.md

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,13 +38,13 @@ jobs:
           ./scripts/fix-reports-path-in-github-runner.sh
 
       - name: SonarQube Scan
-        uses: SonarSource/sonarqube-scan-action@v5
+        uses: SonarSource/sonarqube-scan-action@0303d6b62e310685c0e34d0b9cde218036885c4d  # v5.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@0565863a31f2c772f9f0395002a31e3f06189574  # v5.4.0
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:

--- a/scripts/cleanup-old-branches.sh
+++ b/scripts/cleanup-old-branches.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+# Script to cleanup old branches that haven't been modified in the last 2 months
+# Requires GitHub CLI (gh) to be installed and authenticated
+
+set -e
+
+# Default values
+MONTHS_OLD=2
+PROTECTED_BRANCHES="^(master|develop)$"
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --months)
+      MONTHS_OLD="$2"
+      shift 2
+      ;;
+    --protected-branches)
+      PROTECTED_BRANCHES="$2"
+      shift 2
+      ;;
+    *)
+      echo "Unknown parameter: $1"
+      exit 1
+      ;;
+  esac
+done
+
+# Calculate the cutoff date (2 months ago)
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  # macOS date command
+  CUTOFF_DATE=$(date -v-${MONTHS_OLD}m +%Y-%m-%d)
+else
+  # GNU date command
+  CUTOFF_DATE=$(date -d "${MONTHS_OLD} months ago" +%Y-%m-%d)
+fi
+
+echo "Starting branch cleanup process..."
+echo "Cutoff date: ${CUTOFF_DATE}"
+echo "Protected branches pattern: ${PROTECTED_BRANCHES}"
+
+# Get all remote branches
+BRANCHES=$(git branch -r | grep -v "HEAD" | sed 's/origin\///')
+
+# Counter for deleted branches
+DELETED_COUNT=0
+
+for BRANCH in $BRANCHES; do
+  # Skip protected branches
+  if echo "$BRANCH" | grep -qE "$PROTECTED_BRANCHES"; then
+    echo "Skipping protected branch: $BRANCH"
+    continue
+  fi
+
+  # Get the last commit date for the branch
+  LAST_COMMIT_DATE=$(git log -1 --format=%cd --date=short origin/$BRANCH)
+
+  # Skip if branch has open PRs
+  if gh pr list --head "$BRANCH" --state open --json number | grep -q "number"; then
+    echo "Skipping branch with open PR: $BRANCH"
+    continue
+  fi
+
+  # Compare dates
+  if [[ "$LAST_COMMIT_DATE" < "$CUTOFF_DATE" ]]; then
+    echo "Deleting branch: $BRANCH (last commit: $LAST_COMMIT_DATE)"
+    git push origin --delete "$BRANCH" || {
+      echo "Failed to delete branch: $BRANCH"
+      continue
+    }
+    ((DELETED_COUNT++))
+  fi
+done
+
+echo "Branch cleanup completed."
+echo "Total branches deleted: $DELETED_COUNT" 


### PR DESCRIPTION
## Description of the change

I've used the exact versions for the external GitHub actions and also replaced some of them with custom implementations.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

N/A

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
