### PR TITLE
chore: disable npm lifecycle scripts

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true


### PR DESCRIPTION
Disabled NPM lifecyle scripts for additional safety.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured package installation to skip lifecycle scripts, resulting in more predictable and faster installs.
  * Minimizes unexpected prompts or side effects during dependency installation.
  * Improves consistency across local and CI environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->