### PR TITLE
fix(security)!: eliminate RCE vulnerability in persistence queue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
         "md5": "2.3.0",
         "ms": "2.1.3",
         "remove-trailing-slash": "0.1.1",
-        "serialize-javascript": "7.0.0",
         "uuid": "11.1.0"
       },
       "devDependencies": {
@@ -94,6 +93,7 @@
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -3477,6 +3477,7 @@
       "integrity": "sha512-/SQdmUP2xa+1rdx7VwB9yPq8PaKej8TD5cQ+XfKDPWWC+VDJU4rvVVagXqKUzhKjtFoNA8rXDJAkCxQPAe00+Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.12.0"
       }
@@ -3790,6 +3791,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4010,7 +4012,6 @@
       "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -4267,8 +4268,7 @@
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
       "integrity": "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/async-function": {
       "version": "1.0.0",
@@ -4432,7 +4432,6 @@
       "integrity": "sha512-Xm7bpRXnDSX2YE2YFfBk2FnF0ep6tmG7xPh8iHee8MIcrgq762Nkce856dYtJYLkuIoYZvGfTs/PbZhideTcEg==",
       "dev": true,
       "license": "MPL-2.0",
-      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -4442,6 +4441,7 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.2.tgz",
       "integrity": "sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.4",
@@ -4466,7 +4466,6 @@
       "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -4869,6 +4868,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.3",
         "caniuse-lite": "^1.0.30001741",
@@ -8510,6 +8510,7 @@
       "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
@@ -8686,8 +8687,7 @@
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
       "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
       "dev": true,
-      "license": "BSD-2-Clause",
-      "peer": true
+      "license": "BSD-2-Clause"
     },
     "node_modules/dargs": {
       "version": "8.1.0",
@@ -9466,7 +9466,8 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1464554.tgz",
       "integrity": "sha512-CAoP3lYfwAGQTaAXYvA6JZR0fjGUb7qec1qf4mToyoH2TZgUFeIqYcjh6f9jNuhHfuZiEdH+PONHYrLhRQX6aw==",
       "dev": true,
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/diff": {
       "version": "7.0.0",
@@ -10001,6 +10002,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -10403,6 +10405,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -10491,6 +10494,7 @@
       "integrity": "sha512-jDex9s7D/Qial8AGVIHq4W7NswpUD5DPDL2RH8Lzd9EloWUuvUkHfv4FRLMipH5q2UtyurorBkPeNi1wVWNh3Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "builtins": "^5.0.1",
         "eslint-plugin-es": "^4.1.0",
@@ -10530,6 +10534,7 @@
       "integrity": "sha512-57Zzfw8G6+Gq7axm2Pdo3gW/Rx3h9Yywgn61uE/3elTCOePEHVrn2i5CdfBwA1BLK0Q0WqctICIUSqXZW/VprQ==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
@@ -10546,6 +10551,7 @@
       "integrity": "sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "array-includes": "^3.1.8",
         "array.prototype.findlast": "^1.2.5",
@@ -12422,24 +12428,6 @@
         "conventional-commits-parser": {
           "optional": true
         }
-      }
-    },
-    "node_modules/git-semver-tags/node_modules/conventional-commits-parser": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.2.0.tgz",
-      "integrity": "sha512-uLnoLeIW4XaoFtH37qEcg/SXMJmKF4vi7V0H2rnPueg+VEtFGA/asSCNTcq4M/GQ6QmlzchAEtOoDTtKqWeHag==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "meow": "^13.0.0"
-      },
-      "bin": {
-        "conventional-commits-parser": "dist/cli/index.js"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/git-semver-tags/node_modules/semver": {
@@ -15198,8 +15186,7 @@
       "resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.23.tgz",
       "integrity": "sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ==",
       "dev": true,
-      "license": "CC0-1.0",
-      "peer": true
+      "license": "CC0-1.0"
     },
     "node_modules/language-tags": {
       "version": "1.0.9",
@@ -15207,7 +15194,6 @@
       "integrity": "sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "language-subtag-registry": "^0.3.20"
       },
@@ -19143,6 +19129,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -20823,15 +20810,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/serialize-javascript": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.0.tgz",
-      "integrity": "sha512-pgLqXJrPEahCSuSLFvmBbIi6C769CQkpG509G8lwnaltznys3QxinnJE71cr78TOr6OPi+boskt4NvRbhfgFrA==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
     "node_modules/serve-static": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.0.tgz",
@@ -21047,6 +21025,7 @@
       "integrity": "sha512-2kpQq2DD/pRpx3Tal/qRW1SYwcIeQ0iq8li5CJHQgOC+FtPn2BVmuDtzUCgNnpCrbgtfEHqh+iWzxK+Tq6C+RQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "bytes-iec": "^3.1.1",
         "chokidar": "^4.0.3",
@@ -22779,7 +22758,6 @@
       "integrity": "sha512-o7+c9bW6zpAdJHTtujeePODAhkuicdAryFsfVKwA+wGw89wJ4GTY484WTucM9hLtDEOpOvI+aHnzqnC5lHp4Rg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "call-bind": "^1.0.7",
         "define-properties": "^1.2.1",
@@ -23729,6 +23707,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "md5": "2.3.0",
     "ms": "2.1.3",
     "remove-trailing-slash": "0.1.1",
-    "serialize-javascript": "7.0.0",
     "uuid": "11.1.0"
   },
   "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,14 +1,11 @@
 /* eslint-disable func-names */
 /* eslint-disable sonarjs/no-nested-functions */
-/* eslint-disable sonarjs/code-eval */
 /* eslint-disable no-param-reassign */
 /* eslint-disable no-underscore-dangle */
-/* eslint-disable no-eval */
 /* eslint-disable prefer-destructuring */
 
 const assert = require('assert');
 const removeSlash = require('remove-trailing-slash');
-const serialize = require('serialize-javascript');
 const axios = require('axios');
 const axiosRetry = require('axios-retry').default;
 const ms = require('ms');
@@ -25,6 +22,8 @@ const version = require('../package.json').version;
 const gzip = zlib.gzipSync;
 const setImmediate = global.setImmediate || process.nextTick.bind(process);
 const noop = () => {};
+
+const JOB_DATA_VERSION = 3;
 
 class Analytics {
   /**
@@ -77,6 +76,10 @@ class Analytics {
     this.pQueueInitialized = false;
     this.pQueueOpts = undefined;
     this.pJobOpts = {};
+    // Store callbacks in memory by job ID (v3.0.0 - security fix)
+    // NOTE: Callbacks are NOT persisted to Redis. They will be lost on process restart.
+    // This is intentional to prevent serializing functions (RCE vulnerability).
+    this.pCallbacksMap = new Map();
     this.writeKey = writeKey;
     this.host = removeSlash(dataPlaneUrl || host || 'https://hosted.rudderlabs.com');
     this.path = removeSlash(path || '/v1/batch');
@@ -117,6 +120,22 @@ class Analytics {
     }
   }
 
+  _deserializeJobData(job) {
+    try {
+      if (job.data?.version === JOB_DATA_VERSION) {
+        return JSON.parse(job.data.eventData);
+      }
+
+      this.logger.error(
+        'Job data format is not supported. Please drain your Redis queue before upgrading to v3.0.0.',
+      );
+      // <= v2.x jobs are not supported
+    } catch (error) {
+      this.logger.error('Cannot parse the job data.', error);
+    }
+    return undefined;
+  }
+
   addPersistentQueueProcessor() {
     const _isErrorRetryable = this._isErrorRetryable.bind(this);
     const rdone = (callbacks, err) => {
@@ -128,34 +147,61 @@ class Analytics {
     const payloadQueue = this.pQueue;
     const jobOpts = this.pJobOpts;
 
-    this.pQueue.on('failed', function (job, error) {
-      const jobData = eval(`(${job.data.eventData})`);
-      this.logger.error(`job : ${jobData.description} ${error}`);
+    this.pQueue.on('failed', (job, error) => {
+      const jobData = this._deserializeJobData(job);
+      if (jobData) {
+        this.logger.error(`job : ${jobData.description} ${error}`);
+      }
     });
 
     // tapping on queue events
-    this.pQueue.on('completed', function (job, result) {
-      const jobData = eval(`(${job.data.eventData})`);
-      result = result || 'completed';
-      this.logger.debug(`job : ${jobData.description} ${result}`);
+    this.pQueue.on('completed', (job, result) => {
+      const jobData = this._deserializeJobData(job);
+      if (jobData) {
+        result = result || 'completed';
+        this.logger.debug(`job : ${jobData.description} ${result}`);
+      }
     });
 
-    this.pQueue.on('stalled', function (job) {
-      const jobData = eval(`(${job.data.eventData})`);
-      this.logger.warn(`job : ${jobData.description} is stalled...`);
+    this.pQueue.on('stalled', (job) => {
+      const jobData = this._deserializeJobData(job);
+      if (jobData) {
+        this.logger.warn(`job : ${jobData.description} is stalled...`);
+      }
     });
 
     this.pQueue.process((job, done) => {
       // job failed for maxAttempts or more times, push to failed queue
       // starting with attempt = 0
       const maxAttempts = jobOpts.maxAttempts || 10;
-      const jobData = eval(`(${job.data.eventData})`);
-      if (jobData.attempts >= maxAttempts) {
-        done(
-          new Error(
-            `job : ${jobData.description} pushed to failed queue after attempts ${jobData.attempts} skipping further retries...`,
-          ),
+
+      const jobData = this._deserializeJobData(job);
+      if (!jobData) {
+        done(new Error('Skipping the job because the job data could not be parsed.'));
+        return;
+      }
+
+      // Retrieve callbacks from in-memory map
+      // NOTE: Callbacks will be empty if process restarted, as they are stored in-memory only.
+      // This is a security trade-off to prevent serializing functions (RCE vulnerability).
+      // Users will not receive callback notifications for jobs in-flight during restart.
+      const callbacks = this.pCallbacksMap.get(jobData.jobId) || [];
+
+      if (callbacks.length === 0 && jobData.attempts === 0) {
+        this.logger.warn(
+          `No callbacks found for job ${jobData.jobId}. This may indicate the process restarted with jobs in Redis queue.`
         );
+      }
+
+      if (jobData.attempts >= maxAttempts) {
+        // Clean up callbacks after max attempts exceeded
+        this.pCallbacksMap.delete(jobData.jobId);
+
+        const error = new Error(
+          `job : ${jobData.description} pushed to failed queue after attempts ${jobData.attempts} skipping further retries...`,
+        );
+        rdone(callbacks, error);
+        done(error);
       } else {
         // process the job after exponential delay, if it's the 0th attempt, setTimeout will fire immediately
         // max delay is 30 sec, it is mostly in sync with a bull queue job max lock time
@@ -173,7 +219,9 @@ class Analytics {
               .post(`${host}${path}`, req.data, req)
               // eslint-disable-next-line no-unused-vars
               .then((response) => {
-                rdone(jobData.callbacks);
+                // Clean up callbacks after successful processing
+                this.pCallbacksMap.delete(jobData.jobId);
+                rdone(callbacks);
                 done();
               })
               .catch((err) => {
@@ -181,28 +229,33 @@ class Analytics {
                 const isRetryable = _isErrorRetryable(err);
                 this.logger.debug(`Request is ${isRetryable ? '' : 'not'} to be retried`);
                 if (isRetryable) {
-                  const { attempts, description, callbacks } = jobData;
+                  const { attempts, description, jobId } = jobData;
                   jobData.attempts = attempts + 1;
                   this.logger.debug(`Request retry attempt ${attempts}`);
                   // increment attempt
                   // add a new job to queue in lifo
+                  // Callbacks remain in map for retry (same jobId)
                   // if able to add, mark the earlier job done with push to completed with a msg
                   // if add to redis queue gives exception, not catching it
                   // in case of redis queue error, mark the job as failed ? i.e add the catch block in below promise ?
                   payloadQueue
-                    .add({ eventData: serialize(jobData) }, { lifo: true })
+                    .add(this._getDataForPersistenceQueue(jobData), { lifo: true })
                     // eslint-disable-next-line no-unused-vars
                     .then((pushedJob) => {
                       done(null, `job : ${description} failed for attempt ${attempts} ${err}`);
                     })
                     .catch((error) => {
                       this.logger.error(`failed to requeue job ${description}`);
+                      // Clean up callbacks after requeue failure
+                      this.pCallbacksMap.delete(jobId);
                       rdone(callbacks, error);
                       done(error);
                     });
                 } else {
                   // if not retryable, mark the job failed and to failed queue for user to retry later
-                  rdone(jobData.callbacks, err);
+                  // Clean up callbacks after non-retryable failure
+                  this.pCallbacksMap.delete(jobData.jobId);
+                  rdone(callbacks, err);
                   done(err);
                 }
               });
@@ -311,10 +364,17 @@ class Analytics {
                     .remove()
                     .then(() => {
                       this.logger.debug('success removed active job');
-                      const jobData = eval(`(${job.data.eventData})`);
+                      const jobData = this._deserializeJobData(job);
+
+                      if (!jobData) {
+                        this.logger.error('Cannot parse the job data. Skipping the job.');
+                        return;
+                      }
+
                       jobData.attempts = 0;
+                      // Note: callbacks will be empty for requeued jobs after restart
                       this.pQueue
-                        .add({ eventData: serialize(jobData) }, { lifo: true })
+                        .add(this._getDataForPersistenceQueue(jobData), { lifo: true })
                         // eslint-disable-next-line no-unused-vars
                         .then((removedJob) => {
                           this.logger.debug('success adding removed job back to queue');
@@ -341,6 +401,14 @@ class Analytics {
         this.logger.error('queue not ready');
         callback(error);
       });
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  _getDataForPersistenceQueue(jobData) {
+    return {
+      version: JOB_DATA_VERSION,
+      eventData: JSON.stringify(jobData),
+    };
   }
 
   _validate(message, type) {
@@ -689,15 +757,18 @@ class Analytics {
         ...req,
         data,
       };
+      const jobId = uuid();
       const eventData = {
-        description: `node-${md5(JSON.stringify(request))}-${uuid()}`,
+        jobId,
+        description: `node-${md5(JSON.stringify(request))}-${jobId}`,
         request,
-        callbacks,
         attempts: 0,
       };
-      // using serialize library as default JSON.stringify mangles with function/callback serialization
+      // Store callbacks in memory map (v3.0.0 security fix - no more serialize-javascript)
+      this.pCallbacksMap.set(jobId, callbacks);
+
       this.pQueue
-        .add({ eventData: serialize(eventData) })
+        .add(this._getDataForPersistenceQueue(eventData))
         // eslint-disable-next-line no-unused-vars
         .then((pushedJob) => {
           this.logger.debug('pushed job to queue');
@@ -708,6 +779,8 @@ class Analytics {
           this.timer = setTimeout(this.flush.bind(this), this.flushInterval);
           this.queue.unshift(items);
           this.state = 'idle';
+          // Clean up callbacks if push to queue failed
+          this.pCallbacksMap.delete(jobId);
           this.logger.error(
             `failed to push to redis queue, in-memory queue size: ${this.queue.length}`,
           );


### PR DESCRIPTION
https://linear.app/rudderstack/issue/SDK-4344/fix-rce-vulnerability

## Summary
Fixes critical **Remote Code Execution (RCE)** vulnerability in Redis persistence queue by replacing `eval()` deserialization with `JSON.parse()`.

## Vulnerability Details
- **Type:** Remote Code Execution (RCE) via Insecure Deserialization
- **Severity:** Critical
- **Attack Vector:** Attacker with Redis write access can inject malicious JavaScript that executes when deserialized
- **Affected Component:** `createPersistenceQueue()` feature using Bull/Redis

## Changes
- ✅ **Remove all `eval()` calls** - Replaced with safe `JSON.parse()`
- ✅ **Remove `serialize-javascript` dependency** - No longer needed
- ✅ **Add versioned data format** - Jobs now include `version: 3` marker
- ✅ **In-memory callback storage** - Store callbacks in `Map` by `jobId` instead of serializing to Redis
- ✅ **Add `_deserializeJobData()` helper** - Centralized deserialization with version checking
- ✅ **Add `_getDataForPersistenceQueue()` helper** - DRY data formatting
- ✅ **Fix event handler `this` binding** - Use arrow functions to preserve correct context

## Security Impact
**Before (v2.x):**
```javascript
eval(`(${job.data.eventData})`) // ⚠️ RCE vulnerability
```

**After (v3.0.0):**
```javascript
JSON.parse(job.data.eventData) // ✅ Safe deserialization
```

## Breaking Changes
🚨 **BREAKING CHANGE:** Redis persistence queue data format changed from v2 to v3.

**Migration Path:**
1. **Recommended:** Drain Redis queue before upgrading
2. **Alternative:** Accept that in-flight v2.x jobs will fail gracefully with clear error messages

**Legacy Job Handling:**
- v3 jobs (`version === 3`): Processed securely with `JSON.parse()`
- v2 jobs (no version field): Rejected with error: "Job data format is not supported. Please drain your Redis queue before upgrading to v3.0.0."

## Testing
- ✅ All 59 unit tests passed
- ✅ RCE attack prevented (verified with PoC-based test)
- ✅ Legitimate v3 data processed correctly
- ✅ Legacy v2 data fails gracefully
- ✅ No eval() code paths remain

## Test Plan
- [ ] Review code changes
- [ ] Run test suite: `npm test`
- [ ] Test with persistence queue enabled
- [ ] Verify legacy jobs fail gracefully
- [ ] Build and package: `npm run package`

## Files Changed
- `src/index.js` - Complete security refactor
- `package.json` - Removed `serialize-javascript` dependency
- `package-lock.json` - Updated lockfile

## Related Issues
Resolves: #RUD-2630

---

**Note:** This is a security-critical fix that should be released as v3.0.0 due to the breaking change in the persistence queue data format.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed serialize-javascript dependency.

* **Bug Fixes**
  * More robust job data handling to avoid crashes on malformed or unsupported persisted data.
  * Improved recovery and requeue behavior with safer processing and clearer failure handling.
  * Callbacks are now managed in-memory, improving runtime reliability (note: callbacks aren’t persisted across restarts).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->