### PR TITLE
fix: repeated gzip on retry with persistence queue

### DIFF
--- a/examples/sample-app/app.js
+++ b/examples/sample-app/app.js
@@ -78,7 +78,7 @@ function test() {
 }
 
 try {
-  test();
+  setTimeout(test, 1000);
 } catch (e) {
   console.log(e.message);
 }

--- a/examples/sample-app/package.json
+++ b/examples/sample-app/package.json
@@ -9,6 +9,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@rudderstack/rudder-sdk-node": "*"
+    "@rudderstack/rudder-sdk-node": "*",
+    "bull": "4.16.5"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -211,13 +211,18 @@ class Analytics {
             const req = jobData.request;
             req.data.sentAt = new Date();
 
+            // Prepare request payload without mutating original data
+            let requestData = req.data;
+            const requestHeaders = { ...req.headers };
+
             if (gzipOption) {
-              req.data = gzip(JSON.stringify(req.data));
-              req.headers['Content-Encoding'] = 'gzip';
+              requestData = gzip(JSON.stringify(req.data));
+              requestHeaders['Content-Encoding'] = 'gzip';
             }
+
             // if request succeeded, mark the job done and move to completed
             axiosInstance
-              .post(`${host}${path}`, req.data, req)
+              .post(`${host}${path}`, requestData, { ...req, headers: requestHeaders })
               // eslint-disable-next-line no-unused-vars
               .then((response) => {
                 // Clean up callbacks after successful processing


### PR DESCRIPTION
Scanned-by: gitleaks 8.30.0

Avoided gzipping in-place on each retry when events are processed using persistence queue.

https://linear.app/rudderstack/issue/SDK-4488/fix-double-gzip-issue-on-events-retry-when-persistence-queue-is

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependencies to include Bull queue library for improved task management.

* **Refactor**
  * Improved request payload handling to enhance data integrity during transmission, particularly when compression is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->