### PR TITLE
fix(vuln): remediate GHA script injection

### DIFF
--- a/.github/workflows/publish-new-release.yml
+++ b/.github/workflows/publish-new-release.yml
@@ -25,10 +25,11 @@ jobs:
 
       - name: Extract version from branch name (for release branches)
         id: extract-version
+        env:
+          BRANCH_NAME: ${{ github.event.pull_request.head.ref }}
         run: |
-          BRANCH_NAME="${{ github.event.pull_request.head.ref }}"
-          VERSION=${BRANCH_NAME#hotfix-}
-          VERSION=${VERSION#release/}
+          VERSION="${BRANCH_NAME#hotfix-}"
+          VERSION="${VERSION#release/}"
 
           echo "release_version=$VERSION" >> $GITHUB_OUTPUT
 
@@ -56,18 +57,20 @@ jobs:
           HUSKY: 0
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CONVENTIONAL_GITHUB_RELEASER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_VERSION: ${{ steps.extract-version.outputs.release_version }}
         run: |
-          git tag -a v${{ steps.extract-version.outputs.release_version }} -m "chore: release v${{ steps.extract-version.outputs.release_version }}"
-          git push origin refs/tags/v${{ steps.extract-version.outputs.release_version }}
+          git tag -a "v${RELEASE_VERSION}" -m "chore: release v${RELEASE_VERSION}"
+          git push origin "refs/tags/v${RELEASE_VERSION}"
           npm run release:github
           echo "DATE=$(date)" >> $GITHUB_ENV
 
       - name: Create pull request into develop
         env:
           GH_TOKEN: ${{ secrets.PAT }}
+          RELEASE_VERSION: ${{ steps.extract-version.outputs.release_version }}
         run: |
-          pr_title="chore(release): merge main into develop after release v${{ steps.extract-version.outputs.release_version }}"
-          
+          pr_title="chore(release): merge main into develop after release v${RELEASE_VERSION}"
+
           # Create PR body with proper formatting
           cat > pr_body.md << EOF
           :crown: **Automated Post-Release PR**
@@ -77,12 +80,12 @@ jobs:
           This ensures that the \`develop\` branch stays up to date with all release-related changes from the \`master\` branch.
 
           ### Details
-          - **Release Version**: v${{ steps.extract-version.outputs.release_version }}
+          - **Release Version**: v${RELEASE_VERSION}
 
           ---
           Please review and merge it before closing the release ticket. :rocket:
           EOF
-          
+
           # Create the PR using GitHub CLI
           gh pr create \
             --base develop \


### PR DESCRIPTION
Replaces direct ${{ github.* }} interpolation in run: blocks with env: indirection. Prevents script injection RCE via crafted branch names or other user-controlled inputs. Ref: SEC-93.