### PR TITLE
ci: make release-please match existing v-prefixed tags

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "node",
+  "include-component-in-tag": false,
   "packages": {
     ".": {
       "changelog-path": "CHANGELOG.md",


### PR DESCRIPTION
## Problem

release-please opened #410 (`release rudder-sdk-node 3.1.0`) with the **entire git history** in the changelog instead of just commits since the last release.

## Root cause

`release-please` defaults `include-component-in-tag` to `true`. For the root package it derived the component `rudder-sdk-node` and looked for release tags shaped like `rudder-sdk-node-v3.0.7`. This repo tags releases as `v3.0.7`, so release-please found **no prior release**, walked all of history, and bumped to `3.1.0`.

(The release-PR branch name gives it away: `release-please--branches--master--components--rudder-sdk-node`.)

## Fix

Set `include-component-in-tag: false` in `release-please-config.json`. release-please now matches the existing `v${version}` tags, finds `v3.0.7`, and diffs only the commits since it.

## After merge

release-please re-runs on the push to `master`, finds `v3.0.7`, and sees only `ci:` / `chore:` commits since (the #409 integration work) — nothing releasable — so it will **close #410** automatically. A correct release PR appears once a `feat:` / `fix:` commit lands.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release version tag naming convention.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rudderlabs/rudder-sdk-node/pull/411?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->