### PR TITLE
ci: cut patch releases for chore/ci commits

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,8 +2,24 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "node",
   "include-component-in-tag": false,
+  "pull-request-title-pattern": "chore: release ${version}",
+  "always-update": true,
+  "changelog-sections": [
+    { "type": "feat", "section": "Features", "hidden": false },
+    { "type": "fix", "section": "Bug Fixes", "hidden": false },
+    { "type": "perf", "section": "Performance Improvements", "hidden": false },
+    { "type": "deps", "section": "Dependencies", "hidden": false },
+    { "type": "revert", "section": "Reverts", "hidden": false },
+    { "type": "chore", "section": "Miscellaneous", "hidden": false },
+    { "type": "ci", "section": "Miscellaneous", "hidden": false },
+    { "type": "build", "section": "Miscellaneous", "hidden": false },
+    { "type": "refactor", "section": "Miscellaneous", "hidden": false },
+    { "type": "test", "section": "Miscellaneous", "hidden": false },
+    { "type": "docs", "section": "Documentation", "hidden": false }
+  ],
   "packages": {
     ".": {
+      "package-name": "@rudderstack/rudder-sdk-node",
       "changelog-path": "CHANGELOG.md",
       "extra-files": ["sonar-project.properties"]
     }


### PR DESCRIPTION
## What

Makes release-please cut a **patch** release for `chore` / `ci` / `build` / `refactor` / etc. commits, not just `feat` / `fix`.

## Why

By default release-please only versions on `feat` (minor) and `fix` (patch); other commit types never trigger a release on their own. The release-please integration shipped in #409 was entirely `ci:` / `chore:` commits, so nothing would have been published.

## How

Un-hides those types in `changelog-sections`. A type that is a non-hidden changelog section becomes releasable — a release containing only `chore`/`ci` commits cuts a **patch** bump, while `feat` still bumps **minor** and breaking changes still bump **major**. Same approach used by other RudderStack repos (`events-tracking-assistant`).

Also adds:
- `pull-request-title-pattern: "chore: release ${version}"` — clean, conventional release-PR title
- `always-update: true` — keeps the Release PR current on every run
- `package-name` — explicit

## Note

This builds on #411 (already merged). `ci:`-only changes (e.g. workflow tweaks) will now also cut npm releases even though they don't change the published tarball — that is the intended trade-off for "every change gets a version".
