### PR TITLE
Fill package license metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "./cjs/index.js",
   "module": "./esm/index.js",
   "types": "./index.d.ts",
-  "license": "",
+  "license": "MIT",
   "repository": "rudderlabs/rudder-sdk-node",
   "author": {
     "name": ""


### PR DESCRIPTION
## Summary

- fill the empty package license metadata with `MIT`
- align npm metadata with the repository license

## Verification

- `npm view @rudderstack/rudder-sdk-node@latest name version license repository homepage bugs --json`
- `node -e "const p=require('./package.json'); if (p.license !== 'MIT') throw new Error('license mismatch'); console.log(p.name, p.version, p.license)"`
- `git diff --check`
- `npm pack --dry-run --ignore-scripts --json`
