### PR TITLE
fix: specify MIT license metadata

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "@rudderstack/rudder-sdk-node",
       "version": "3.0.9",
+      "license": "MIT",
       "dependencies": {
         "axios": "1.17.0",
         "axios-retry": "4.5.0",
@@ -9196,16 +9197,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -9905,9 +9906,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
-      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "./cjs/index.js",
   "module": "./esm/index.js",
   "types": "./index.d.ts",
-  "license": "",
+  "license": "MIT",
   "repository": "rudderlabs/rudder-sdk-node",
   "author": {
     "name": ""


### PR DESCRIPTION
## Summary

- set the package license metadata to `MIT`
- keep the existing `LICENSE.md` contents unchanged, including the Segment MIT notice
- refresh the package lock root metadata so it matches `package.json`
- bump the transitive `form-data` lockfile resolution to `4.0.6` so the high-severity npm audit gate passes

## Context

Refs SDK-4983.

This repo is a clone from one of Segment's repositories, so we should retain the existing MIT license file contents and only specify the package metadata.

## Verification

- `diff -u <(git show master:LICENSE.md) LICENSE.md`
- `node -e "const p=require('./package.json'); const l=require('./package-lock.json'); const fd=l.packages['node_modules/form-data']; if (p.license !== 'MIT') throw new Error('package license mismatch'); if (l.packages[''].license !== 'MIT') throw new Error('lock license mismatch'); if (fd.version !== '4.0.6') throw new Error('form-data mismatch: '+fd.version); console.log({pkg:p.license, lock:l.packages[''].license, formData:fd.version})"`
- `npm audit --omit=dev --audit-level=high`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project license metadata to MIT.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->