### PR TITLE
chore(codeowners): set sdk_team as code owners

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -3,7 +3,7 @@ name: Bug report
 about: Create a report to help us improve
 title: 'BUG : <Title>'
 labels: bug, open source
-assignees: ""
+assignees: []
 ---
 
 **Describe the bug**

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -3,7 +3,7 @@ name: Bug report
 about: Create a report to help us improve
 title: 'BUG : <Title>'
 labels: bug, open source
-assignees: MoumitaM
+assignees: ""
 ---
 
 **Describe the bug**

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @rudderlabs/node-js-sdk
+* @rudderlabs/sdk_team


### PR DESCRIPTION
## Summary

Replaces the repo's code owners with the whole SDK team (`@rudderlabs/sdk_team`) so any team member's review can unblock chore PRs (Dependabot merges, CI fixes) instead of waiting on the `node-js-sdk` sub-team. Part of the SDK-5102 rollout across SDK repos; resolves SDK-5111.

## Changes

- `CODEOWNERS` (repo root): default owner changed from `@rudderlabs/node-js-sdk` to `@rudderlabs/sdk_team`.
- `.github/ISSUE_TEMPLATE/bug_report.md`: default assignee replaced with an empty list (was `MoumitaM`) — GitHub issue assignees only accept individual users, so a team can't be set here; new issues get routed by on-call triage instead.

## Testing

- Verified `@rudderlabs/sdk_team` already has write access on this repo, so GitHub honors it as code owner as soon as this merges — no access changes needed.
- Post-merge check: the next PR should auto-request review from `sdk_team`, and any member's approval should satisfy the code-owner requirement.

## Screenshots

No UI changes in this PR.

## Notes

No breaking changes or migration steps required. Review-routing change only — no code, workflow, or build behavior is affected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the bug report template so issues are not automatically assigned to a specific individual.
  * Updated repository ownership routing for the RudderLabs SDK.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
