### PR TITLE
chore: sdk-5206 configure dependabot security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,52 +1,56 @@
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
+  - package-ecosystem: 'github-actions'
+    directory: '/'
     schedule:
-      interval: "cron"
-      # every wednesday at 00:01 UTC
-      cronjob: "1 0 * * 3"
-      timezone: "UTC"
-    target-branch: "master"
+      interval: 'cron'
+      cronjob: '1 0 * * 3'
+      timezone: 'UTC'
     labels:
-      - "dependencies"
-      - "github-actions"
-    open-pull-requests-limit: 10
+      - 'dependencies'
+      - 'github_actions'
+    # Disable routine version updates while retaining security updates.
+    open-pull-requests-limit: 0
     groups:
-      github-actions-deps:
+      github-actions-security-non-major:
+        applies-to: 'security-updates'
         patterns:
-          - "*"
+          - '*'
+        update-types:
+          - 'minor'
+          - 'patch'
 
-  - package-ecosystem: "npm"
-    cooldown:
-      default-days: 5
-    directory: "/"
+      github-actions-security-major:
+        applies-to: 'security-updates'
+        patterns:
+          - '*'
+        update-types:
+          - 'major'
+
+  - package-ecosystem: 'npm'
+    directories:
+      - '/'
+      - '/examples/*'
     schedule:
-      interval: "cron"
-      # every wednesday at 00:01 UTC
-      cronjob: "1 0 * * 3"
-      timezone: "UTC"
-    target-branch: "master"
+      interval: 'cron'
+      cronjob: '1 0 * * 3'
+      timezone: 'UTC'
     labels:
-      - "dependencies"
-    open-pull-requests-limit: 10
+      - 'dependencies'
+    # Disable routine version updates while retaining security updates.
+    open-pull-requests-limit: 0
     groups:
-      npm-dev-deps:
+      npm-security-non-major:
+        applies-to: 'security-updates'
         patterns:
-          - "*"
-        dependency-type: "development"
-
-      npm-prod-deps:
-        patterns:
-          - "*"
+          - '*'
         update-types:
-          - "minor"
-          - "patch"
-        dependency-type: "production"
+          - 'minor'
+          - 'patch'
 
-      npm-prod-major-deps:
+      npm-security-major:
+        applies-to: 'security-updates'
         patterns:
-          - "*"
+          - '*'
         update-types:
-          - "major"
-        dependency-type: "production"
+          - 'major'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,7 @@ updates:
     labels:
       - 'dependencies'
       - 'github_actions'
+      - 'security_updates'
     # Disable routine version updates while retaining security updates.
     open-pull-requests-limit: 0
     groups:
@@ -45,6 +46,7 @@ updates:
       default-days: 7
     labels:
       - 'dependencies'
+      - 'security_updates'
     # Disable routine version updates while retaining security updates.
     open-pull-requests-limit: 0
     groups:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,10 @@ updates:
       interval: 'cron'
       cronjob: '1 0 * * 3'
       timezone: 'UTC'
+    # Applies only if routine version updates are re-enabled; security updates
+    # are intentionally not delayed by Dependabot cooldowns.
+    cooldown:
+      default-days: 7
     labels:
       - 'dependencies'
       - 'github_actions'
@@ -35,6 +39,10 @@ updates:
       interval: 'cron'
       cronjob: '1 0 * * 3'
       timezone: 'UTC'
+    # Applies only if routine version updates are re-enabled; security updates
+    # are intentionally not delayed by Dependabot cooldowns.
+    cooldown:
+      default-days: 7
     labels:
       - 'dependencies'
     # Disable routine version updates while retaining security updates.


### PR DESCRIPTION
## Summary

- disable routine Dependabot version-update PRs for npm and GitHub Actions while retaining security updates
- cover the root package and all manifests under `examples/*`
- separate major security upgrades from minor/patch security upgrades for explicit compatibility review
- use the repository's existing `github_actions` label

## Why

This reduces routine dependency-update noise without disabling Dependabot vulnerability remediation. Major security upgrades remain isolated so they can be assessed for SDK compatibility and release impact before merging.

## Release impact

No SDK runtime or public API change. This configuration-only change does not require a major SDK release.

## Validation

- Prettier check for `.github/dependabot.yml`
- YAML parsing and semantic policy assertions
- `git diff --check`

Linear: https://linear.app/rudderstack/issue/SDK-5206/configure-node-sdk-dependabot-for-security-updates-only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency management settings.
  * Routine version update pull requests are now disabled.
  * Security updates remain enabled, with separate handling for major and non-major updates.
  * Security coverage now includes dependencies in example projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->