### PR TITLE
chore: sdk-5206 schedule quarterly dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,19 +3,13 @@ updates:
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
-      interval: 'cron'
-      cronjob: '1 0 * * 3'
-      timezone: 'UTC'
-    # Applies only if routine version updates are re-enabled; security updates
-    # are intentionally not delayed by Dependabot cooldowns.
+      interval: 'quarterly'
     cooldown:
       default-days: 7
     labels:
       - 'dependencies'
       - 'github_actions'
-      - 'security_updates'
-    # Disable routine version updates while retaining security updates.
-    open-pull-requests-limit: 0
+    open-pull-requests-limit: 2
     groups:
       github-actions-security-non-major:
         applies-to: 'security-updates'
@@ -32,23 +26,32 @@ updates:
         update-types:
           - 'major'
 
+      github-actions-version-non-major:
+        applies-to: 'version-updates'
+        patterns:
+          - '*'
+        update-types:
+          - 'minor'
+          - 'patch'
+
+      github-actions-version-major:
+        applies-to: 'version-updates'
+        patterns:
+          - '*'
+        update-types:
+          - 'major'
+
   - package-ecosystem: 'npm'
     directories:
       - '/'
       - '/examples/*'
     schedule:
-      interval: 'cron'
-      cronjob: '1 0 * * 3'
-      timezone: 'UTC'
-    # Applies only if routine version updates are re-enabled; security updates
-    # are intentionally not delayed by Dependabot cooldowns.
+      interval: 'quarterly'
     cooldown:
       default-days: 7
     labels:
       - 'dependencies'
-      - 'security_updates'
-    # Disable routine version updates while retaining security updates.
-    open-pull-requests-limit: 0
+    open-pull-requests-limit: 4
     groups:
       npm-security-non-major:
         applies-to: 'security-updates'
@@ -60,6 +63,40 @@ updates:
 
       npm-security-major:
         applies-to: 'security-updates'
+        patterns:
+          - '*'
+        update-types:
+          - 'major'
+
+      npm-development-non-major:
+        applies-to: 'version-updates'
+        dependency-type: 'development'
+        patterns:
+          - '*'
+        update-types:
+          - 'minor'
+          - 'patch'
+
+      npm-development-major:
+        applies-to: 'version-updates'
+        dependency-type: 'development'
+        patterns:
+          - '*'
+        update-types:
+          - 'major'
+
+      npm-production-non-major:
+        applies-to: 'version-updates'
+        dependency-type: 'production'
+        patterns:
+          - '*'
+        update-types:
+          - 'minor'
+          - 'patch'
+
+      npm-production-major:
+        applies-to: 'version-updates'
+        dependency-type: 'production'
         patterns:
           - '*'
         update-types:

--- a/.github/workflows/label-dependabot-security-updates.yml
+++ b/.github/workflows/label-dependabot-security-updates.yml
@@ -1,0 +1,45 @@
+name: Label Dependabot security updates
+
+on:
+  schedule:
+    - cron: '23 * * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  label-security-update:
+    name: Label Dependabot security updates
+    if: github.repository == 'rudderlabs/rudder-sdk-node'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: read
+
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      # Every security update matches one of the configured group identifiers,
+      # so its Dependabot branch contains "security".
+      - name: Label open security update pull requests
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          gh pr list \
+            --repo "$REPOSITORY" \
+            --state open \
+            --author 'app/dependabot' \
+            --limit 100 \
+            --json url,headRefName \
+            --jq '.[] | select(.headRefName | contains("security")) | .url' |
+            while read -r pr_url; do
+              gh pr edit "$pr_url" --add-label security_updates
+            done

--- a/.github/workflows/label-dependabot-security-updates.yml
+++ b/.github/workflows/label-dependabot-security-updates.yml
@@ -14,7 +14,6 @@ permissions: {}
 jobs:
   label-security-update:
     name: Label Dependabot security updates
-    if: github.repository == 'rudderlabs/rudder-sdk-node'
     runs-on: ubuntu-latest
     permissions:
       issues: write

--- a/.github/workflows/label-dependabot-security-updates.yml
+++ b/.github/workflows/label-dependabot-security-updates.yml
@@ -29,6 +29,7 @@ jobs:
       # Every security update matches one of the configured group identifiers,
       # so its Dependabot branch contains "security".
       - name: Label open security update pull requests
+        shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
           REPOSITORY: ${{ github.repository }}


### PR DESCRIPTION
## Purpose

Keep dependencies moving without flooding the team: address known vulnerabilities as soon as Dependabot detects them, while batching routine npm and GitHub Actions upgrades into a quarterly maintenance cycle.

This is a follow-up to #457, which established security-focused Dependabot coverage for GitHub Actions, the root npm package, and packages under `examples/*`.

## What this changes

### Security updates

- remain event-driven and are not held until the quarterly maintenance window
- remain grouped separately into major and non-major updates
- receive the `security_updates` label
- keep major security upgrades isolated for explicit compatibility and release-impact review

### Routine version updates

- run quarterly for npm and GitHub Actions
- use a seven-day cooldown before newly released versions become eligible
- separate major updates from minor and patch updates
- split npm updates by development and production dependencies
- cap open routine PRs at:
  - two for GitHub Actions
  - four for npm

## Coverage

Dependabot monitors:

- GitHub Actions under `.github/workflows`
- the root npm package
- npm packages under `examples/*`

## Security labeling

Dependabot's ecosystem-level `labels` setting applies to both security and routine version updates.

To keep the `security_updates` label exclusive to vulnerability-driven PRs, an hourly least-privilege workflow labels open Dependabot PRs belonging to the configured security groups.

The workflow does not check out or execute pull-request code. The hourly schedule affects only when the label is applied; it does not delay creation of security update PRs.

## Release impact

This PR changes repository dependency-maintenance configuration only.

It does not change the SDK runtime or public API and does not require a major SDK release. Any future major dependency upgrade will still be raised separately and reviewed for compatibility and release impact before merging.

## Validation

- Prettier checks for both YAML files
- YAML parsing and semantic policy assertions
- zizmor 1.26.1: no findings
- `git diff --check`

Linear: https://linear.app/rudderstack/issue/SDK-5206/configure-node-sdk-dependabot-for-security-updates-only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated automated dependency update schedules and grouping for clearer handling of major, minor/patch, development, and production updates.
  - Increased the allowed number of open automated update requests.
  - Added an automated workflow to label security-related dependency update pull requests for easier identification and tracking.
  - Refined dependency-related label handling for more consistent organization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->