### PR TITLE
fix: sdk-5232 restore package entry points

### DIFF
--- a/.github/workflows/build-and-quality-checks.yml
+++ b/.github/workflows/build-and-quality-checks.yml
@@ -45,5 +45,4 @@ jobs:
 
       - name: Generate build
         run: |
-          npm run build:cjs
-          npm run build:esm
+          npm run package

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "pre-commit": "npm run test && npx lint-staged",
     "commit-msg": "commitlint --edit",
     "commit": "git-cz",
-    "package": "npm run build:cjs && npm run build:esm && npm run copy:assets",
+    "package": "npm run build:cjs && npm run build:esm && npm run copy:assets && npm run check:package",
+    "check:package": "node scripts/check-package.js",
     "clean": "rm -rf dist && git clean -xdf node_modules",
     "setup": "npm install",
     "test:sample": "npm run package && cd examples/sample-app && npm run test:local"

--- a/scripts/check-package.js
+++ b/scripts/check-package.js
@@ -8,9 +8,23 @@ const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
 
 for (const field of ['main', 'module', 'types']) {
   assert.strictEqual(typeof manifest[field], 'string', `package.json is missing "${field}"`);
+  assert.ok(!path.isAbsolute(manifest[field]), `${field} entry point must be relative`);
+  assert.ok(
+    !manifest[field].split(/[\\/]+/).includes('..'),
+    `${field} entry point must not escape the package root`,
+  );
 
   const entryPoint = path.resolve(packageRoot, manifest[field]);
-  assert.ok(fs.existsSync(entryPoint), `${field} entry point does not exist: ${manifest[field]}`);
+  const relativeEntryPoint = path.relative(packageRoot, entryPoint);
+  assert.ok(
+    relativeEntryPoint &&
+      !relativeEntryPoint.startsWith(`..${path.sep}`) &&
+      !path.isAbsolute(relativeEntryPoint),
+    `${field} entry point must remain within the package root`,
+  );
+
+  const entryPointStats = fs.statSync(entryPoint, { throwIfNoEntry: false });
+  assert.ok(entryPointStats?.isFile(), `${field} entry point is not a file: ${manifest[field]}`);
 }
 
 const sdk = require(packageRoot);

--- a/scripts/check-package.js
+++ b/scripts/check-package.js
@@ -1,0 +1,23 @@
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const packageRoot = path.resolve(__dirname, '..', 'dist');
+const manifestPath = path.join(packageRoot, 'package.json');
+const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+
+for (const field of ['main', 'module', 'types']) {
+  assert.strictEqual(typeof manifest[field], 'string', `package.json is missing "${field}"`);
+
+  const entryPoint = path.resolve(packageRoot, manifest[field]);
+  assert.ok(fs.existsSync(entryPoint), `${field} entry point does not exist: ${manifest[field]}`);
+}
+
+const sdk = require(packageRoot);
+assert.strictEqual(
+  typeof sdk,
+  'function',
+  'CommonJS entry point does not export the SDK constructor',
+);
+
+console.log('Packaged SDK entry points are valid.');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "module": "ESNext",
     "target": "es2015",
     "moduleResolution": "bundler",
+    "rootDir": "./src",
     "lib": ["es2020"],
     "outDir": "./dist/esm",
     "declarationDir": "./dist/types",


### PR DESCRIPTION
## Summary

Restore the publishable Node SDK entry-point layout after the TypeScript 7 migration and add a package-level smoke test.

TypeScript 7 inferred the repository root as the common source directory because `src/index.js` reads `../package.json`. Builds still succeeded, but output moved from `dist/{cjs,esm}/index.js` to `dist/{cjs,esm}/src/index.js`, while the published manifest continued pointing to the original paths. The resulting package failed to load with `MODULE_NOT_FOUND`.

## Changes

- Set `rootDir` to `src` so CJS, ESM, and declaration output retain the published layout.
- Validate the declared `main`, `module`, and `types` files during packaging.
- Load the packaged CommonJS entry point and verify it exports the SDK constructor.
- Run the real packaging command in PR CI, matching the release workflow.

## Validation

- `HUSKY=0 npm ci`
- `npm run package`
- Consumer `require('./dist')` smoke test
- `npm run check:lint`
- `npm run test:ci` — 59 passed, 4 skipped
- Prettier check for changed files
- `npm pack --dry-run --json ./dist`

## Tracking

- [SDK-5232](https://linear.app/rudderstack/issue/SDK-5232/fix-node-sdk-package-entry-points-after-typescript-7-migration)
- Blocks release PR #450
- Regression introduced by the toolchain migration in #459

This restores the existing package contract and remains a patch-level fix.