### PR TITLE
chore: update readme with new branding images

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,10 @@
 
 <p align="center">
   <a href="https://rudderstack.com/">
-    <img src="https://raw.githubusercontent.com/rudderlabs/rudder-sdk-js/develop/assets/rs-logo-full-light.jpg">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/rudderlabs/rudder-sdk-js/develop/assets/rs-logo-full-dark.png">
+      <img alt="RudderStack" width="512" src="https://raw.githubusercontent.com/rudderlabs/rudder-sdk-js/develop/assets/rs-logo-full-light.jpg">
+    </picture>
   </a>
 </p>
 


### PR DESCRIPTION
# Description

Makes the README logo theme-aware: wraps it in a `<picture>` element serving the new dark variant in dark mode, with the light asset as default/fallback. The image content itself already updated when rudderlabs/rudder-sdk-js#3159 merged (this README hotlinks the canonical asset from that repo) — this PR only adds dark-mode support and the standard alt/width attributes.

npm's package page keeps rendering the light `<img>` fallback, so nothing changes there.

Docs-only change.

Linear: https://linear.app/rudderstack/issue/SDK-5116/update-sdk-repositories-and-packaged-assets-with-new-branding-images